### PR TITLE
[Sync] Update project files from source repository (9d58dbe)

### DIFF
--- a/.github/actions/validate-test-results/action.yml
+++ b/.github/actions/validate-test-results/action.yml
@@ -221,6 +221,20 @@ runs:
         # Strip backticks AND control chars (except tab/newline) from artifact-derived text:
         # prevents code-span/fenced-block breakout and control-character (ANSI/NUL) spoofing.
         strip_bt() { printf '%s' "$1" | LC_ALL=C tr -d '\000-\010\013-\037\140\177'; }
+        # esc_html: strip_bt PLUS escape the HTML metacharacters &, <, > (& first, to avoid
+        # double-encoding). Use ONLY for artifact-derived values written into the summary's raw
+        # HTML (<summary>/<code>) or into markdown text where GitHub interprets inline HTML —
+        # otherwise a crafted value (e.g. a subtest name) could close a tag early and spoof the
+        # rendered structure. Do NOT use inside markdown code spans/fences, where entities are
+        # rendered literally (there strip_bt alone already prevents breakout).
+        esc_html() {
+          local s
+          s=$(strip_bt "$1")
+          s=${s//&/&amp;}
+          s=${s//</&lt;}
+          s=${s//>/&gt;}
+          printf '%s' "$s"
+        }
 
         echo "## 🔍 Test Validation Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -279,7 +293,7 @@ runs:
               ARTIFACT_DIR=$(basename "$(dirname "$jsonl_file")")
             fi
 
-            TEST_LABEL=$(strip_bt "$(parse_test_label "$ARTIFACT_DIR" "$JSONL_NAME")")
+            TEST_LABEL=$(esc_html "$(parse_test_label "$ARTIFACT_DIR" "$JSONL_NAME")")
 
             SUMMARY=$(grep '"type":"summary"' "$jsonl_file" 2>/dev/null | head -1 || echo "")
 
@@ -315,11 +329,14 @@ runs:
                 break 2
               fi
 
-              # Strip backticks from artifact-derived text so it cannot break out of the
-              # markdown code spans / fenced blocks it is written into below.
-              TEST=$(strip_bt "$(echo "$line" | jq -r '.failure.test // "unknown"')")
-              PKG=$(strip_bt "$(echo "$line" | jq -r '.failure.package // "unknown"' | sed 's|.*/||')")
-              FAIL_TYPE=$(strip_bt "$(echo "$line" | jq -r '.failure.type // "test"')")
+              # TEST/PKG/FAIL_TYPE are embedded directly in the raw HTML of the <summary>
+              # line below (<code>$TEST</code> ($PKG) - $FAIL_TYPE), so they are HTML-escaped
+              # to keep a crafted value from closing a tag early and spoofing the structure.
+              # ERROR_MSG/OUTPUT/STACK go inside markdown code spans/fences, where HTML is not
+              # interpreted, so backtick+control stripping (strip_bt) is enough there.
+              TEST=$(esc_html "$(echo "$line" | jq -r '.failure.test // "unknown"')")
+              PKG=$(esc_html "$(echo "$line" | jq -r '.failure.package // "unknown"' | sed 's|.*/||')")
+              FAIL_TYPE=$(esc_html "$(echo "$line" | jq -r '.failure.type // "test"')")
               ERROR_MSG=$(strip_bt "$(echo "$line" | jq -r '.failure.error // ""')")
               OUTPUT=$(strip_bt "$(echo "$line" | jq -r '.failure.output // ""')")
               STACK=$(strip_bt "$(echo "$line" | jq -r '.failure.stack // ""')")

--- a/.github/workflows/fortress.yml
+++ b/.github/workflows/fortress.yml
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------------
 #  🏰 GoFortress - Enterprise-grade CI/CD fortress for Go applications
 #
-#  Version: 1.8.1 | Released: 2026-05-29
+#  Version: 1.9.0 | Released: 2026-08-13
 #
 #  Built Strong. Tested Harder.
 #


### PR DESCRIPTION
## What Changed

* Added new `esc_html()` bash function in `.github/actions/validate-test-results/action.yml` that escapes HTML metacharacters (`&`, `<`, `>`) in addition to stripping backticks and control characters
* Updated `TEST_LABEL`, `TEST`, `PKG`, and `FAIL_TYPE` variables to use `esc_html()` instead of `strip_bt()` when these values are embedded in raw HTML elements (`<summary>` and `<code>` tags)
* Kept `ERROR_MSG`, `OUTPUT`, and `STACK` variables using `strip_bt()` as they are placed inside markdown code spans/fences where HTML is not interpreted
* Updated fortress.yml version header from `Version: 1.8.1 | Released: 2026-05-29` to `Version: 1.9.0 | Released: 2026-08-13`

## Why It Was Necessary

* Prevents HTML injection attacks where crafted test names or package names could close tags early and spoof the rendered structure of the GitHub Actions summary
* Addresses a security vulnerability where artifact-derived values written directly into raw HTML were not properly escaped, allowing potential manipulation of the CI output display
* Distinguishes between contexts where HTML escaping is required (raw HTML elements) versus where backtick stripping alone is sufficient (markdown code blocks)

## Testing Performed

* Verified that test labels, test names, package names, and failure types containing HTML metacharacters are properly escaped in the GitHub Actions summary output
* Confirmed that error messages, output, and stack traces in code blocks still function correctly with backtick/control stripping only
* Validated that the new `esc_html()` function correctly chains `strip_bt()` and applies HTML entity encoding in the proper order (ampersand first to avoid double-encoding)

## Impact / Risk

* **Security improvement**: Closes a potential HTML injection vector in CI/CD test result reporting
* **Low risk**: Changes are defensive in nature and only affect display formatting of test validation summaries
* **No breaking changes**: The escaping is transparent to legitimate test names and only affects maliciously crafted input that was previously exploitable

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 2
  files_with_original_content: 2
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 9d58dbe7c38b1688a0d14b919069d32354f8cfaf
  target_repo: mrz1836/go-datastore
  sync_commit: e0817006cc5992d9907399598cb51e2f116982e0
  sync_time: 2026-08-14T18:49:30-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 283
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1537
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 476
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 779
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 286
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1388
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1868
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 617
performance:
  total_files: 103
-->
